### PR TITLE
Hardknott

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,6 @@ BBFILE_COLLECTIONS += "asteroid-community-layer"
 BBFILE_PATTERN_asteroid-community-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_asteroid-community-layer = "7"
 
-LAYERSERIES_COMPAT_asteroid-community-layer = "gatesgarth"
+LAYERSERIES_COMPAT_asteroid-community-layer = "hardknott"
 
 PACKAGE_FEED += "retroarch asteroid-2048 neofetch"

--- a/recipes-retroarch/retroarch/retroarch_git.bb
+++ b/recipes-retroarch/retroarch/retroarch_git.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "https://www.retroarch.com/"
 BUGTRACKER = "https://github.com/libretro/RetroArch/issues"
 
 LICENSE = "GPLv3"
-LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0;md5=c79ff39f19dfec6d293b95dea7b07891"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-3.0-only;md5=c79ff39f19dfec6d293b95dea7b07891"
 
 PR = "r1"
 PV = "+git${SRCPV}"


### PR DESCRIPTION
- Bump to hardknott
- `oe-core` has removed the `${COMMON_LICENSE_DIR}/GPL-3.0` file. The same license with the same checksum is now available under `${COMMON_LICENSE_DIR}/GPL-3.0-only`