### PR TITLE
Add SuperTuxKart

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PRIORITY_asteroid-community-layer = "7"
 
 LAYERSERIES_COMPAT_asteroid-community-layer = "honister"
 
-PACKAGE_FEED += "retroarch asteroid-2048 neofetch"
+PACKAGE_FEED += "retroarch asteroid-2048 supertuxkart neofetch"

--- a/recipes-games/supertuxkart/supertuxkart/0001-Fix-compilation-with-latest-SDL.patch
+++ b/recipes-games/supertuxkart/supertuxkart/0001-Fix-compilation-with-latest-SDL.patch
@@ -1,0 +1,111 @@
+From 61833c9c26da5520f2eaa02f2458971ba07f2aad Mon Sep 17 00:00:00 2001
+From: Benau <Benau@users.noreply.github.com>
+Date: Sun, 29 Nov 2020 12:42:11 +0800
+Subject: [PATCH] Fix compilation with latest SDL
+
+
+Upstream-Status: Accepted [https://github.com/supertuxkart/stk-code/commit/61833c9c26da5520f2eaa02f2458971ba07f2aad]
+---
+ src/input/gamepad_config.cpp | 55 ++++++++++++++++++------------------
+ 1 file changed, 27 insertions(+), 28 deletions(-)
+
+diff --git a/src/input/gamepad_config.cpp b/src/input/gamepad_config.cpp
+index 7c6f63209..c060e7a5a 100644
+--- a/src/input/gamepad_config.cpp
++++ b/src/input/gamepad_config.cpp
+@@ -32,8 +32,7 @@
+ #include "input/sdl_controller.hpp"
+ #include <array>
+ 
+-static_assert(SDL_CONTROLLER_BUTTON_MAX - 1 == SDL_CONTROLLER_BUTTON_DPAD_RIGHT, "non continous name");
+-enum AxisWithDirection
++enum AxisWithDirection : unsigned
+ {
+     SDL_CONTROLLER_AXIS_LEFTX_RIGHT = SDL_CONTROLLER_BUTTON_MAX,
+     SDL_CONTROLLER_AXIS_LEFTX_LEFT,
+@@ -140,56 +139,56 @@ void GamepadConfig::setDefaultBinds ()
+ core::stringw GamepadConfig::getBindingAsString(const PlayerAction action) const
+ {
+ #ifndef SERVER_ONLY
+-    std::array<core::stringw, SDL_CONTROLLER_AXIS_WITH_DIRECTION_AND_BUTTON_MAX> readable =
++    std::map<unsigned, core::stringw> readable =
+     {{
+-        "A", // SDL_CONTROLLER_BUTTON_A
+-        "B", // SDL_CONTROLLER_BUTTON_B
+-        "X", // SDL_CONTROLLER_BUTTON_X
+-        "Y", // SDL_CONTROLLER_BUTTON_Y
++        { SDL_CONTROLLER_BUTTON_A, "A" },
++        { SDL_CONTROLLER_BUTTON_B, "B" },
++        { SDL_CONTROLLER_BUTTON_X, "X" },
++        { SDL_CONTROLLER_BUTTON_Y, "Y" },
+         // I18N: name of buttons on gamepads
+-        _("Back"), // SDL_CONTROLLER_BUTTON_BACK
++        { SDL_CONTROLLER_BUTTON_BACK, _("Back") },
+         // I18N: name of buttons on gamepads
+-        _("Guide"), // SDL_CONTROLLER_BUTTON_GUIDE
++        { SDL_CONTROLLER_BUTTON_GUIDE, _("Guide") },
+         // I18N: name of buttons on gamepads
+-        _("Start"), // SDL_CONTROLLER_BUTTON_START
++        { SDL_CONTROLLER_BUTTON_START, _("Start") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick press"), // SDL_CONTROLLER_BUTTON_LEFTSTICK
++        { SDL_CONTROLLER_BUTTON_LEFTSTICK, _("Left thumbstick press") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick press"), // SDL_CONTROLLER_BUTTON_RIGHTSTICK
++        { SDL_CONTROLLER_BUTTON_RIGHTSTICK, _("Right thumbstick press") },
+         // I18N: name of buttons on gamepads
+-        _("Left shoulder"), // SDL_CONTROLLER_BUTTON_LEFTSHOULDER
++        { SDL_CONTROLLER_BUTTON_LEFTSHOULDER, _("Left shoulder") },
+         // I18N: name of buttons on gamepads
+-        _("Right shoulder"), // SDL_CONTROLLER_BUTTON_RIGHTSHOULDER
++        { SDL_CONTROLLER_BUTTON_RIGHTSHOULDER, _("Right shoulder") },
+         // I18N: name of buttons on gamepads
+-        _("DPad up"), // SDL_CONTROLLER_BUTTON_DPAD_UP
++        { SDL_CONTROLLER_BUTTON_DPAD_UP, _("DPad up") },
+         // I18N: name of buttons on gamepads
+-        _("DPad down"), // SDL_CONTROLLER_BUTTON_DPAD_DOWN
++        { SDL_CONTROLLER_BUTTON_DPAD_DOWN, _("DPad down") },
+         // I18N: name of buttons on gamepads
+-        _("DPad left"), // SDL_CONTROLLER_BUTTON_DPAD_LEFT
++        { SDL_CONTROLLER_BUTTON_DPAD_LEFT, _("DPad left") },
+         // I18N: name of buttons on gamepads
+-        _("DPad right"), // SDL_CONTROLLER_BUTTON_DPAD_RIGHT
++        { SDL_CONTROLLER_BUTTON_DPAD_RIGHT, _("DPad right") },
+ 
+         // Below are extensions after SDL2 header SDL_CONTROLLER_BUTTON_MAX
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick right"), // SDL_CONTROLLER_AXIS_LEFTX_RIGHT
++        { SDL_CONTROLLER_AXIS_LEFTX_RIGHT, _("Left thumbstick right") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick left"), // SDL_CONTROLLER_AXIS_LEFTX_LEFT
++        { SDL_CONTROLLER_AXIS_LEFTX_LEFT, _("Left thumbstick left") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick down"), // SDL_CONTROLLER_AXIS_LEFTY_DOWN
++        { SDL_CONTROLLER_AXIS_LEFTY_DOWN, _("Left thumbstick down") },
+         // I18N: name of buttons on gamepads
+-        _("Left thumbstick up"), // SDL_CONTROLLER_AXIS_LEFTY_UP
++        { SDL_CONTROLLER_AXIS_LEFTY_UP, _("Left thumbstick up") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick right"), // SDL_CONTROLLER_AXIS_RIGHTX_RIGHT
++        { SDL_CONTROLLER_AXIS_RIGHTX_RIGHT, _("Right thumbstick right") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick left"), // SDL_CONTROLLER_AXIS_RIGHTX_LEFT
++        { SDL_CONTROLLER_AXIS_RIGHTX_LEFT, _("Right thumbstick left") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick down"), // SDL_CONTROLLER_AXIS_RIGHTY_DOWN
++        { SDL_CONTROLLER_AXIS_RIGHTY_DOWN, _("Right thumbstick down") },
+         // I18N: name of buttons on gamepads
+-        _("Right thumbstick up"), // SDL_CONTROLLER_AXIS_RIGHTY_UP
++        { SDL_CONTROLLER_AXIS_RIGHTY_UP, _("Right thumbstick up") },
+         // I18N: name of buttons on gamepads
+-        _("Left trigger"), // SDL_CONTROLLER_AXIS_TRIGGERLEFT_UP
++        { SDL_CONTROLLER_AXIS_TRIGGERLEFT_UP, _("Left trigger") },
+         // I18N: name of buttons on gamepads
+-        _("Right trigger") // SDL_CONTROLLER_AXIS_TRIGGERRIGHT_UP
++        { SDL_CONTROLLER_AXIS_TRIGGERRIGHT_UP, _("Right trigger") }
+     }};
+ 
+     const Binding &b = getBinding(action);
+-- 
+2.26.2
+

--- a/recipes-games/supertuxkart/supertuxkart_1.2.bb
+++ b/recipes-games/supertuxkart/supertuxkart_1.2.bb
@@ -1,0 +1,44 @@
+DESCRIPTION = "SuperTuxKart is a kart racing game featuring Tux and his friends"
+HOMEPAGE = "http://supertuxkart.sourceforge.net"
+LICENSE = "GPLv2 & GPLv3+ & CC-BY-SA-3.0 & CC-BY-SA-4.0 & PD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=bcfdeb69518cfe348a07845ebba5c295"
+
+DEPENDS = " \
+    libogg \
+    libvorbis \
+    virtual/libgles2 \
+    openal-soft \
+    fribidi \
+    curl \
+    libpng \
+    libjpeg-turbo \
+    freetype \
+    bluez5 \
+    harfbuzz \
+    libsdl2 \
+"
+
+inherit cmake
+
+SRC_URI = " \
+    https://github.com/supertuxkart/stk-code/releases/download/${PV}/SuperTuxKart-${PV}-src.tar.xz \
+    file://0001-Fix-compilation-with-latest-SDL.patch \
+"
+
+SRC_URI[sha256sum] = "052edf0afdbeb99583fe8676fb0ab80ecb6103fb88b7540f858d1b5fa1297d37"
+
+S = "${WORKDIR}/SuperTuxKart-${PV}-src"
+
+EXTRA_OECMAKE = " \
+    -DUSE_GLES2=ON \
+    -DBUILD_RECORDER=0 \
+"
+PACKAGECONFIG ??= " \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'wayland', d)} \
+"
+PACKAGECONFIG[wayland] = "-DENABLE_WAYLAND_DEVICE=ON,-DENABLE_WAYLAND_DEVICE=OFF,wayland"
+
+FILES:${PN} += " \
+    ${datadir}/icons \
+    ${datadir}/metainfo \
+"


### PR DESCRIPTION
This PR adds support for SuperTuxKart 1.2.

It still requires some manual changes to the configuration as most watches are limited by the low amount of memory.

In a future work I will update SuperTuxKart to 1.3 (which improves performance on slower CPUs) and provide this custom configuration. But this should already be enough to let people play with the game :wink: 