### PR TITLE
Add Qmltester.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PRIORITY_asteroid-community-layer = "7"
 
 LAYERSERIES_COMPAT_asteroid-community-layer = "honister"
 
-PACKAGE_FEED += "retroarch supertuxkart neofetch"
+PACKAGE_FEED += "retroarch supertuxkart neofetch asteroid-qmltester"

--- a/recipes-devtools/asteroid-qmltester/asteroid-qmltester_git.bb
+++ b/recipes-devtools/asteroid-qmltester/asteroid-qmltester_git.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Asteroid's qmltester app"
+HOMEPAGE = "https://github.com/MagneFire/asteroid-qmltester.git"
+LICENSE = "GPLv3"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
+
+SRC_URI = "git://github.com/MagneFire/asteroid-qmltester.git;protocol=https"
+SRCREV = "${AUTOREV}"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+inherit cmake_qt5
+
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
+FILES:${PN} += "/usr/share/translations/"


### PR DESCRIPTION
This PR adds the qmltester app to the community repo as it has been a very useful utility for me (and I have the impression for @eLtMosen too).

Adding this to the community repo and package feed makes the package version stay in sync with the current upstream, which reduces issues in general :P