### PR TITLE
Add desktop-file-utils prerequisite to fix vim

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PRIORITY_asteroid-community-layer = "7"
 
 LAYERSERIES_COMPAT_asteroid-community-layer = "honister"
 
-PACKAGE_FEED += "retroarch neofetch asteroid-qmltester vim nano unofficial-watchfaces"
+PACKAGE_FEED += "retroarch neofetch asteroid-qmltester vim desktop-file-utils nano unofficial-watchfaces"


### PR DESCRIPTION
This fixes issue #9 by adding desktop-file-utils to the layer so that it
will be possible to install vim without errors.