### PR TITLE
Feature/gpsp gpsp menu updates

### DIFF
--- a/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
+++ b/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
@@ -4,9 +4,9 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/MagneFire/gpsp-menu.git;protocol=https;branch=master \
-    file://gpsp.conf"
-SRCREV = "67573b7551883d959ea543bb652dfbf33e883c46"
-PR = "r1"
+           file://gpsp.conf \
+           "
+SRCREV = "db73a3ad451546a5f43af54b04efeff7889ebdae"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit cmake_qt5 pkgconfig

--- a/recipes-gameboy/gpsp/gpsp_git.bb
+++ b/recipes-gameboy/gpsp/gpsp_git.bb
@@ -4,8 +4,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING.DOC;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
 SRC_URI = "git://github.com/MagneFire/gpsp.git;protocol=https;branch=master"
-SRCREV = "408d3748dbfe16122e6cfaa21899f828c7cad5e2"
-PR = "r1"
+SRCREV = "dfe442f693cf7710ceb6073109f80e3eca4ad756"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Update `gpsp-menu` to incorporate the recent extra-cmake-modules syntax change (https://github.com/AsteroidOS/meta-asteroid/pull/105).

Update `gpsp` to fix a rendering issue on `minnow`.