### PR TITLE
Add asteroid-map, a map app for asteroidos

### DIFF
--- a/recipes-navigation/asteroid-map/asteroid-map_v1.0.bb
+++ b/recipes-navigation/asteroid-map/asteroid-map_v1.0.bb
@@ -1,0 +1,22 @@
+SUMMARY = "Map app for AsteroidOS"
+iHOMEPAGE = "https://git.dodorad.io/dodoradio/asteroid-map/about"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
+
+SRC_URI = "git://git.dodorad.io/dodoradio/asteroid-map;protocol=https;branch=master"
+SRCREV = "79c43f735fedc45fae6c5d72ade70f0012cef530"
+PR = "r1"
+PV = "+git${SRCPV}"
+S = "${WORKDIR}/git"
+inherit cmake_qt5
+
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native qtlocation"
+RDEPENDS:${PN} += "qtlocation"
+
+FILES:${PN} += "/usr/share/icons/asteroid"
+
+do_install:append() {
+    # This app only uses translations for the desktop shortcut.
+    rm -rvf ${D}/usr/share/translations/
+}
+


### PR DESCRIPTION
I've set it to build a static revision, hence it's called _v1-0.bb - I'm not entirely sure this is the correct naming format? If I'm understanding this https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-fetching.html#git-fetcher-git regarding tags correctly, it's not best practice to use tags as the version reference as it means the build system always needs a network connection to be able to check remote. 

the repo is at https://git.dodorad.io/dodoradio/asteroid-map . 