### PR TITLE
Update asteroid-qmltester and gpsp-menu

### DIFF
--- a/recipes-devtools/asteroid-qmltester/asteroid-qmltester_git.bb
+++ b/recipes-devtools/asteroid-qmltester/asteroid-qmltester_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/MagneFire/asteroid-qmltester.git;protocol=https;branch=master"
-SRCREV = "${AUTOREV}"
+SRCREV = "de2672f6da72699112839e2151ef6a3ac83f52c6"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
+++ b/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 SRC_URI = "git://github.com/MagneFire/gpsp-menu.git;protocol=https;branch=master \
            file://gpsp.conf \
            "
-SRCREV = "db73a3ad451546a5f43af54b04efeff7889ebdae"
+SRCREV = "befd3e9e23673107f45cde6f60daac9de7eaf3ab"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit cmake_qt5 pkgconfig


### PR DESCRIPTION
Incorporates the following changes:
- https://github.com/MagneFire/gpsp-menu/commit/befd3e9e23673107f45cde6f60daac9de7eaf3ab: Fixes the settings cog positioned at the top left instead of the middle bottom.
- https://github.com/MagneFire/asteroid-qmltester/commit/de2672f6da72699112839e2151ef6a3ac83f52c6: Fixes an issue where button presses could not be detected in the loaded qml.