### PR TITLE
conf: Mark layer as compatible with Mickledore.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,6 @@ BBFILE_COLLECTIONS += "asteroid-community-layer"
 BBFILE_PATTERN_asteroid-community-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_asteroid-community-layer = "7"
 
-LAYERSERIES_COMPAT_asteroid-community-layer = "kirkstone"
+LAYERSERIES_COMPAT_asteroid-community-layer = "kirkstone mickledore"
 
 PACKAGE_FEED += "retroarch neofetch asteroid-qmltester vim desktop-file-utils nano unofficial-watchfaces cronie asteroid-map asteroid-weatherfetch"


### PR DESCRIPTION
This is needed as part of https://github.com/AsteroidOS/asteroid/issues/245.