### PR TITLE
Add recipe for asteroid-weatherfetch

### DIFF
--- a/recipes-asteroid/asteroid-weatherfetch/asteroid-weatherfetch_git.bb
+++ b/recipes-asteroid/asteroid-weatherfetch/asteroid-weatherfetch_git.bb
@@ -1,0 +1,15 @@
+SUMMARY = "Fetch weather forecast data for asteroid-weather"
+HOMEPAGE = "https://github.com/beroset/asteroid-weatherfetch.git"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
+
+SRC_URI = "git://github.com/beroset/asteroid-weatherfetch.git;protocol=https;branch=master"
+SRCREV = "a20036a78cb1d9a84e97aed545794a1afedc9046"
+PV = "1.0+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+inherit cmake_qt5 pkgconfig
+
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native glibmm"
+RDEPENDS:${PN} += "nemo-qml-plugin-notifications asteroid-virtualkeyboard"
+FILES:${PN} += "/usr/share/translations/"


### PR DESCRIPTION
This adds the asteroid-weatherfetch application so that a user on a watch with an internet connection (e.g. WiFi or USB) can easily fetch weather forecast data for the asteroid-weather application.  It fixes #24 