### PR TITLE
gpsp: Fix crashes and scaling issues

### DIFF
--- a/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
+++ b/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 SRC_URI = "git://github.com/MagneFire/gpsp-menu.git;protocol=https;branch=master \
            file://gpsp.conf \
            "
-SRCREV = "befd3e9e23673107f45cde6f60daac9de7eaf3ab"
+SRCREV = "63709f167488c4b563bbb5a37d48c9028dd1d4d6"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit cmake_qt5 pkgconfig

--- a/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
+++ b/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
@@ -6,9 +6,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 SRC_URI = "git://github.com/MagneFire/gpsp-menu.git;protocol=https;branch=master \
            file://gpsp.conf \
            "
-SRCREV = "63709f167488c4b563bbb5a37d48c9028dd1d4d6"
+SRCREV = "2bddcaabefe2530b236951827553347b8c743835"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
+
+UPSTREAM_CHECK_COMMITS = "1"
+
 inherit cmake_qt5 pkgconfig
 
 FILES:${PN} += "/usr/share/icons/asteroid/"

--- a/recipes-gameboy/gpsp/gpsp_git.bb
+++ b/recipes-gameboy/gpsp/gpsp_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING.DOC;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
 SRC_URI = "git://github.com/MagneFire/gpsp.git;protocol=https;branch=master"
-SRCREV = "dfe442f693cf7710ceb6073109f80e3eca4ad756"
+SRCREV = "322fca7e7aeeceb95658c3daeeecf8d958fb3cbb"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 

--- a/recipes-gameboy/gpsp/gpsp_git.bb
+++ b/recipes-gameboy/gpsp/gpsp_git.bb
@@ -4,12 +4,13 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING.DOC;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
 SRC_URI = "git://github.com/MagneFire/gpsp.git;protocol=https;branch=master"
-SRCREV = "322fca7e7aeeceb95658c3daeeecf8d958fb3cbb"
+SRCREV = "6ed8f36e1009f5dbf645265d9fe5825259226737"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 
-
 FILES:${PN} += "/usr/share/gpsp/"
+
+UPSTREAM_CHECK_COMMITS = "1"
 
 inherit pkgconfig
 
@@ -30,5 +31,5 @@ do_install() {
     cp game_config.txt ${D}/usr/share/gpsp/
 }
 
-DEPENDS += "libsdl2"
+DEPENDS += "libsdl2 mcedevel dbus"
 RDEPENDS:${PN} += "libsdl2"


### PR DESCRIPTION
Fix segfaults whenever environment variables weren't set due to the combination of `getenv()` with `sprintf()`. The previous logic appeared to work fine on `kirkstone` but resulted in segfaults on `mickledore`.

Refactor the scaling logic such that scaling is only applied on round displays (whenever the `ROUND` environment variable is set).