### PR TITLE
gpsp: Bump SRCREV to add support for multi-device mappings.

### DIFF
--- a/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
+++ b/recipes-gameboy/gpsp-menu/gpsp-menu_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 SRC_URI = "git://github.com/MagneFire/gpsp-menu.git;protocol=https;branch=master \
            file://gpsp.conf \
            "
-SRCREV = "2bddcaabefe2530b236951827553347b8c743835"
+SRCREV = "e1fc1b0aa3b3f32a78c8744665de58ac86d30284"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 

--- a/recipes-gameboy/gpsp/gpsp_git.bb
+++ b/recipes-gameboy/gpsp/gpsp_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING.DOC;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
 SRC_URI = "git://github.com/MagneFire/gpsp.git;protocol=https;branch=master"
-SRCREV = "6ed8f36e1009f5dbf645265d9fe5825259226737"
+SRCREV = "c387966e366b40350d9899260c8086e0fd3aa686"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Basically changes the method on how mappings are stored to disc and how they are loaded.
Instead of relying on the joystick interface id rely on the GUID. This makes mappings more consistent when more controllers are connected.

Additionally, allow multiple controllers to control the emulator.
Furthermore, this includes some minor fixes where mapping would skip the first button and it not being functional on the main window.