### PR TITLE
asteroid-health: add sensorlogd as runtime dependency

### DIFF
--- a/recipes-asteroid/asteroid-health/asteroid-health_v0.9.bb
+++ b/recipes-asteroid/asteroid-health/asteroid-health_v0.9.bb
@@ -12,5 +12,5 @@ inherit cmake_qt5 pkgconfig
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools qtsensors asteroid-sensorlogd"
 FILES:${PN} += "/usr/lib/"
-RDEPENDS:${PN} += ""
+RDEPENDS:${PN} += "asteroid-sensorlogd"
 


### PR DESCRIPTION
This was previously not added due to my misunderstanding of how this dependency works