### PR TITLE
Use revision with proper file handling

### DIFF
--- a/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
+++ b/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 SRC_URI = "git://github.com/beroset/asteroid-skedaddle.git;protocol=https;branch=main"
 
 PV = "1.0+git"
-SRCREV = "b7b834a76f5ba6526dcdbc77767e05bfd8ab49ab"
+SRCREV = "38f8e6f0b05d0ff4ba88e9ef95b4e662ff2ddbf1"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This bumps the srcrev to point to an updated version which uses proper file handling rather than the hack of abusing XMLHttpRequest.