### PR TITLE
Update asteroid-skedaddle and add to layers

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PRIORITY_asteroid-community-layer = "7"
 
 LAYERSERIES_COMPAT_asteroid-community-layer = "kirkstone mickledore scarthgap"
 
-PACKAGE_FEED += "retroarch neofetch asteroid-qmltester vim desktop-file-utils nano unofficial-watchfaces cronie asteroid-map asteroid-weatherfetch asteroid-sensorlogd asteroid-health asteroid-dodger"
+PACKAGE_FEED += "retroarch neofetch asteroid-qmltester vim desktop-file-utils nano unofficial-watchfaces cronie asteroid-map asteroid-weatherfetch asteroid-sensorlogd asteroid-health asteroid-dodger asteroid-skedaddle"

--- a/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
+++ b/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 SRC_URI = "git://github.com/beroset/asteroid-skedaddle.git;protocol=https;branch=main"
 
 PV = "1.0+git"
-SRCREV = "38f8e6f0b05d0ff4ba88e9ef95b4e662ff2ddbf1"
+SRCREV = "926ab26387b353025c4fc576f8e007b80c4590a0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This updates asteroid-skedaddle to the latest version and adds it to the meta-asteroid-community layers so that it can be installed via opkg.