### PR TITLE
gpsp: Bump SRCREV to load OpenGL

### DIFF
--- a/recipes-gameboy/gpsp/gpsp_git.bb
+++ b/recipes-gameboy/gpsp/gpsp_git.bb
@@ -3,8 +3,8 @@ HOMEPAGE = "https://github.com/MagneFire/gpsp"
 LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING.DOC;md5=892f569a555ba9c07a568a7c0c4fa63a"
 
-SRC_URI = "git://github.com/MagneFire/gpsp.git;protocol=https;branch=master"
-SRCREV = "cc286647af745543d0583ac9398b32427a581ef4"
+SRC_URI = "git://github.com/MagneFire/gpsp.git;protocol=https;branch=main"
+SRCREV = "d74f472b447ddd646c09c929bd7fd2419f1842f7"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This also fixes issues with Yocto walnascar: https://github.com/AsteroidOS/asteroid/issues/298