### PR TITLE
Add qtlocation as RDEPENDS

### DIFF
--- a/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
+++ b/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
@@ -13,5 +13,5 @@ S = "${WORKDIR}/git"
 inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native espeak"
-RDEPENDS:${PN} += "espeak"
+RDEPENDS:${PN} += "espeak qtlocation"
 FILES:${PN} += "/usr/share/translations/"


### PR DESCRIPTION
This application requires qtlocation but did not list it as a runtime dependency.  This fixes that omission.