### PR TITLE
Update dependency

### DIFF
--- a/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
+++ b/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
@@ -13,5 +13,5 @@ S = "${WORKDIR}/git"
 inherit cmake_qt5
 
 DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native espeak"
-RDEPENDS:${PN} += "espeak qtlocation"
+RDEPENDS:${PN} += "espeak qtlocation-qmlplugins"
 FILES:${PN} += "/usr/share/translations/"


### PR DESCRIPTION
This updates the dependency to qtlocation-qmlplugins instead of just qtlocation.  Both are needed, but specifying just qtlocation-qmlplugins gets both because that package depends on qtlocation.