### PR TITLE
asteroid-hackwatch: Initial commit

### DIFF
--- a/recipes-devtools/asteroid-hackwatch/asteroid-hackwatch_git.bb
+++ b/recipes-devtools/asteroid-hackwatch/asteroid-hackwatch_git.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Asteroid HackWatch app"
+HOMEPAGE = "https://github.com/Snoarlax/asteroid-hack"
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
+
+PV = "0.0.1"
+PR = "r1"
+
+SRC_URI = "git://github.com/Snoarlax/asteroid-hack.git;protocol=https;branch=master"
+SRCREV = "5bbb1c5e6a0020334791314f8db4f511edf0ca1e"
+
+S = "${WORKDIR}/git"
+EXTRA_OECMAKE += "-DCPACK_PACKAGE_CONTACT='snoarsec@gmail.com'"
+inherit cmake_qt5
+
+DEPENDS = "qml-asteroid qtbase qtdeclarative extra-cmake-modules asteroid-generate-desktop-native"
+
+RDEPENDS:${PN} = "qtbase qtdeclarative asteroid-launcher"
+
+FILES:${PN} += "/usr/lib/libasteroid-hack.so"
+FILES:${PN}-dev = ""

--- a/recipes-devtools/asteroid-hackwatch/asteroid-hackwatch_git.bb
+++ b/recipes-devtools/asteroid-hackwatch/asteroid-hackwatch_git.bb
@@ -3,19 +3,27 @@ HOMEPAGE = "https://github.com/Snoarlax/asteroid-hack"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-PV = "0.0.1"
-PR = "r1"
+PV = "1.0.0+git${SRCPV}"
+PR = "r0"
 
-SRC_URI = "git://github.com/Snoarlax/asteroid-hack.git;protocol=https;branch=master"
-SRCREV = "5bbb1c5e6a0020334791314f8db4f511edf0ca1e"
-
+SRC_URI = "git://github.com/Snoarlax/asteroid-hack;protocol=https;branch=master"
+SRCREV = "b2af485c78e26e18e950e3e064584b0765c163e5"
 S = "${WORKDIR}/git"
+
 EXTRA_OECMAKE += "-DCPACK_PACKAGE_CONTACT='snoarsec@gmail.com'"
 inherit cmake_qt5
 
 DEPENDS = "qml-asteroid qtbase qtdeclarative extra-cmake-modules asteroid-generate-desktop-native"
+RDEPENDS:${PN} = "qtbase qtdeclarative asteroid-launcher sudo"
 
-RDEPENDS:${PN} = "qtbase qtdeclarative asteroid-launcher"
+do_compile:append() {
+    ${CC} ${CFLAGS} ${LDFLAGS} ${S}/src/utilities/keyboard_interface.c -o ${B}/keyboard_interface
+}
 
-FILES:${PN} += "/usr/lib/libasteroid-hack.so"
+do_install:append() {
+    install -d ${D}/usr/bin/
+    install -m 0755 ${B}/keyboard_interface ${D}/usr/bin/keyboard_interface
+}
+
+FILES:${PN} += "/usr/lib/libasteroid-hack.so /usr/bin/keyboard_interface"
 FILES:${PN}-dev = ""


### PR DESCRIPTION
Contains bb script for pulling the v 0.1 release of asteroid-hack, a tool that allows arbitrary shell scripts to be stored and run off the UI. Also features keyboard emulation for storing and running premade keyboard scripts.