### PR TITLE
Update community apps to use asteroid namespace

### DIFF
--- a/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
+++ b/recipes-asteroid/asteroid-skedaddle/asteroid-skedaddle_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 SRC_URI = "git://github.com/beroset/asteroid-skedaddle.git;protocol=https;branch=main"
 
 PV = "1.1+git"
-SRCREV = "5ce29d6837c32bccdd66b6be86629167cbd5701a"
+SRCREV = "b20817a8720cda286e6fd09d98eecb14b2cd6795"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-asteroid/asteroid-weatherfetch/asteroid-weatherfetch_git.bb
+++ b/recipes-asteroid/asteroid-weatherfetch/asteroid-weatherfetch_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/beroset/asteroid-weatherfetch.git;protocol=https;branch=master"
-SRCREV = "8c479fa2bb7e29986c43060cd0104e2d3baaffe9"
+SRCREV = "9047883470d79b6e6383849e4d282c5f7ddd4c3c"
 PV = "2.0.0"
 S = "${WORKDIR}/git"
 

--- a/recipes-navigation/asteroid-map/asteroid-map_v1.0.bb
+++ b/recipes-navigation/asteroid-map/asteroid-map_v1.0.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-map.git;protocol=https;branch=master"
-SRCREV = "0e7507f8e04d046a8cde96f914b8863c441e7be2"
+SRCREV = "56a456a967b8658bcc836ed2484564e3697ee1de"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This advances the recipe commit hash for asteroid-skedaddle, asteroid-weatherfetch and asteroid-map to the latest versions which are the same as the previous ones with the sole addition that they now use the Asteroid:: namespace to qualify the AsteroidApp link.

Those were each the complementary change to
https://github.com/AsteroidOS/qml-asteroid/pull/83