### PR TITLE
Add missing apps to PACKAGE_FEED

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,4 +13,5 @@ LAYERSERIES_COMPAT_asteroid-community-layer = "walnascar"
 PACKAGE_FEED += " \
     neofetch asteroid-qmltester vim desktop-file-utils nano unofficial-watchfaces cronie asteroid-map \
     asteroid-weatherfetch asteroid-sensorlogd asteroid-health asteroid-dodger asteroid-skedaddle asteroid-blaster asteroid-shopper \
+    asteroid-hackwatch asteroid-meteormatch asteroid-horizon asteroid-pulsar asteroid-heliograph asteroid-beatfork asteroid-touchdown \
 "


### PR DESCRIPTION
asteroid-hackwatch, asteroid-meteormatch, asteroid-horizon, asteroid-pulsar, asteroid-heliograph, asteroid-beatfork, and asteroid-touchdown were missing from the opkg package feed list.