### PR TITLE
Health and sensorlogd: bump to v0.91

### DIFF
--- a/recipes-asteroid/asteroid-health/asteroid-health_v0.91.bb
+++ b/recipes-asteroid/asteroid-health/asteroid-health_v0.91.bb
@@ -4,9 +4,9 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-health.git;protocol=https;branch=master"
-SRCREV = "c5aea9086f7f25d2f3ebca5041da69a64d41eb68"
+SRCREV = "3e78747b68d3867608a3d8e2c24463839039d235"
 PR = "r1"
-PV = "0.9+git${SRCPV}"
+PV = "0.91+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 

--- a/recipes-asteroid/asteroid-health/asteroid-sensorlogd_v0.91.bb
+++ b/recipes-asteroid/asteroid-health/asteroid-sensorlogd_v0.91.bb
@@ -4,13 +4,13 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SRC_URI = "git://github.com/AsteroidOS/asteroid-sensorlogd.git;protocol=https;branch=master"
-SRCREV = "f46ac73ac2398f9dbb069012b3cf6d569760bcf0"
+SRCREV = "bdc9f0bb0fd6ef39f08fb01697d95cb2b98c86b6"
 PR = "r1"
-PV = "0.9+git${SRCPV}"
+PV = "0.91+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
-DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools qtdeclarative-native qttools-native qtsensors"
+DEPENDS += "qml-asteroid asteroid-generate-desktop-native qttools qtdeclarative-native qttools-native qtsensors mlite"
 FILES:${PN} += "/usr/lib/"
 RDEPENDS:${PN} += ""
 


### PR DESCRIPTION
This bumps the revisions and package versions on asteroid-health to v0.91. The changes there are mostly just a qt6 migration, but also some accumulated commits such as translations.