### PR TITLE
Update moWerk apps to Qt6

### DIFF
--- a/recipes-asteroid/asteroid-beatfork/asteroid-beatfork.bb
+++ b/recipes-asteroid/asteroid-beatfork/asteroid-beatfork.bb
@@ -3,22 +3,15 @@ HOMEPAGE = "https://github.com/moWerk/asteroid-beatfork"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 SRC_URI = "git://github.com/moWerk/asteroid-beatfork.git;protocol=https;branch=master"
-SRCREV = "3165fca021a78a2f63abdb5e6bf9cf754c384fb0"
+SRCREV = "cb81362f2c07ffb7ee07a0198f144c4069185c7c"
 PR = "r1"
 PV = "1.0+git${SRCPV}"
 S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
-DEPENDS += "nemo-keepalive qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
+DEPENDS += "nemo-keepalive qtmultimedia qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
 do_install:append() {
     install -d ${D}/usr/share/sounds
     install -m 0644 ${S}/src/tick.wav      ${D}/usr/share/sounds
-    install -m 0644 ${S}/src/392hz.wav     ${D}/usr/share/sounds
-    install -m 0644 ${S}/src/415hz.wav     ${D}/usr/share/sounds
-    install -m 0644 ${S}/src/432hz.wav     ${D}/usr/share/sounds
-    install -m 0644 ${S}/src/440hz.wav     ${D}/usr/share/sounds
-    install -m 0644 ${S}/src/442hz.wav     ${D}/usr/share/sounds
-    install -m 0644 ${S}/src/444hz.wav     ${D}/usr/share/sounds
-    install -m 0644 ${S}/src/452hz.wav     ${D}/usr/share/sounds
 }
 FILES:${PN} += "/usr/share/translations/ /usr/share/sounds/"
 

--- a/recipes-asteroid/asteroid-heliograph/asteroid-heliograph_git.bb
+++ b/recipes-asteroid/asteroid-heliograph/asteroid-heliograph_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/moWerk/asteroid-heliograph.git;protocol=https;branch=main"
-SRCREV = "675d2289f628e9b3f7d164f004db0b6053425b1e"
+SRCREV = "612fd6b1e9229cbacb5f724bc21e239cd034f632"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
@@ -12,6 +12,7 @@ S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
 DEPENDS:append = " nemo-keepalive qml-asteroid qtsensors qttools-native qtdeclarative-native"
+RDEPENDS:${PN} += "qtsensors-qmlplugins"
 
 do_install:append() {
     install -d ${D}/home/ceres/.local/share/asteroid-heliograph

--- a/recipes-asteroid/asteroid-horizon/asteroid-horizon_git.bb
+++ b/recipes-asteroid/asteroid-horizon/asteroid-horizon_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/moWerk/asteroid-horizon.git;protocol=https;branch=main"
-SRCREV = "8a100a1915411f52066c8bc45371f806636dd1e5"
+SRCREV = "3339b36ab549e11949f3399e49ced07e1035ee96"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
@@ -12,6 +12,7 @@ S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
 DEPENDS:append = " qml-asteroid qtsensors nemo-keepalive qttools-native qtdeclarative-native"
+RDEPENDS:${PN} += "qtsensors-qmlplugins"
 
 FILES:${PN}:append = " ${libdir}"
 FILES:${PN}:append = " /usr/share/translations/"

--- a/recipes-asteroid/asteroid-pulsar/asteroid-pulsar_git.bb
+++ b/recipes-asteroid/asteroid-pulsar/asteroid-pulsar_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/moWerk/asteroid-pulsar.git;protocol=https;branch=main"
-SRCREV = "a9cdafaf0567007a30b57fc4788bd788a99c6d07"
+SRCREV = "a7b9339bc6ba882ec0717a45e2edddc1e304cd84"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-asteroid/asteroid-shopper/asteroid-shopper_git.bb
+++ b/recipes-asteroid/asteroid-shopper/asteroid-shopper_git.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/moWerk/asteroid-shopper.git;protocol=https;branch=master"
-SRCREV = "06e9dcc3de8c8b249569ad5c99703d9538c90cbc"
+SRCREV = "c0eea7e655611d060071fa213a64fa03f03de0ff"
 PR = "r2"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-games/asteroid-blaster/asteroid-blaster.bb
+++ b/recipes-games/asteroid-blaster/asteroid-blaster.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SRC_URI = "git://github.com/moWerk/asteroid-blaster.git;protocol=https;branch=main"
-SRCREV = "d4d8a069e369e97bbae59999f6869079327a2563"
+SRCREV = "7947938807d5de4ea7cb918b0241377aac9d3216"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
@@ -12,6 +12,7 @@ S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
 DEPENDS:append = " qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
+RDEPENDS:${PN} += "qtsensors-qmlplugins"
 
 FILES:${PN}:append = " ${libdir}"
 FILES:${PN}:append = " /usr/share/translations/"

--- a/recipes-games/asteroid-dodger/asteroid-dodger.bb
+++ b/recipes-games/asteroid-dodger/asteroid-dodger.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
 SRC_URI = "git://github.com/moWerk/asteroid-dodger.git;protocol=https;branch=master"
-SRCREV = "76e1bdad5d585d76bc8e7979ad1a796faefc43fc"
+SRCREV = "9643d40db9c609a006ed89a87dc1afd907492af1"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
@@ -12,6 +12,7 @@ S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
 DEPENDS:append = " qml-asteroid asteroid-generate-desktop-native qttools-native qtdeclarative-native"
+RDEPENDS:${PN} += "qtsensors-qmlplugins"
 
 FILES:${PN}:append = " ${libdir}"
 FILES:${PN}:append = " /usr/share/translations/"

--- a/recipes-games/asteroid-meteormatch/asteroid-meteormatch.bb
+++ b/recipes-games/asteroid-meteormatch/asteroid-meteormatch.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=45bc9c5afb8cda60dfa1f74c3e6d618d"
 
 SRC_URI = "git://github.com/moWerk/asteroid-meteormatch.git;protocol=https;branch=main"
-SRCREV = "4ab0a1816dd14b37fc90ae5a3b772e7c8c10d2ce"
+SRCREV = "3a597047d1e4021d8eddf715e4c6e110c04080d1"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/recipes-games/asteroid-touchdown/asteroid-touchdown.bb
+++ b/recipes-games/asteroid-touchdown/asteroid-touchdown.bb
@@ -4,7 +4,7 @@ LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
 
 SRC_URI = "git://github.com/moWerk/asteroid-touchdown.git;protocol=https;branch=main"
-SRCREV = "e9c9717b74df015a6fa3b96eeac320cd68193803"
+SRCREV = "52fcb8ee61edd890089d517cf2f580c992c12a52"
 PR = "r1"
 PV = "+git${SRCPV}"
 S = "${WORKDIR}/git"
@@ -12,6 +12,7 @@ S = "${WORKDIR}/git"
 inherit qt6-cmake pkgconfig
 
 DEPENDS:append = " qml-asteroid qttools-native qtdeclarative-native"
+RDEPENDS:${PN} += "qtsensors-qmlplugins"
 
 FILES:${PN}:append = " ${libdir}"
 FILES:${PN}:append = " /usr/share/translations/"


### PR DESCRIPTION
Updates all nine moWerk apps to their merged Qt6 states so they install and run on a Qt6 system, one commit per app.

Each commit bumps the recipe SRCREV to the app's current default-branch tip (the Qt6 port, plus the instantiated `DisplayBlanking` LPM fix where it applied), and completes the recipe so the app actually works at runtime, not just builds:

- **qtsensors** QML plugin as a runtime dep for the accelerometer apps (horizon, blaster, dodger, heliograph, touchdown) — without it the `import QtSensors` fails on device.
- **beatfork**: add `qtmultimedia` (the tuning-fork tones are now synthesised with `QAudioSink`), and drop the seven tone `.wav` installs (392–452hz) that the synthesis replaced and that no longer exist in the source — the old install block referenced missing files.

dodger points at the merged OOP refactor; shopper, pulsar and meteormatch are SRCREV-only.
